### PR TITLE
Rewrite Github URLs to use access token it when cloning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,11 @@ inputs:
     required: false
     default: 'false'
     type: string
+  github-token:
+    description: 'Optionally rewrite all GitHub URLs to authenticate with a personal access token.'
+    required: false
+    default: 'false'
+    type: string
 outputs:
   cache-key:
     value: ${{ steps.compute-cache-key.outputs.cache-key }}
@@ -54,6 +59,11 @@ runs:
         echo "::set-output name=cache-key::$result"
         echo "::set-output name=cache-key-suffix::$suffix"
       shell: bash
+    - name: Configure Git Client with GitHub Auth Token
+      shell: bash
+      if: inputs.github-token != 'false'
+      run: |
+        git config --global url.https://${{ inputs.github-token }}@github.com/.insteadOf git@github.com:
     - id: cache-dependencies
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-4904)

With our private Elixir packages on Github, we define them We reference our private Elixir packages in mix.exs files like this:

```
{:ex_ops, git: "git@github.com:rentpath/ex_ops.git", tag: "3.0.0"}
```

This works well for locally development, but in Github Actions we need to use the Github token from Rossum when cloning repos, and that is only possible via HTTPS, so we re-write the Git URLS and inject the token into them.

[SRV-4904]: https://rentpath.atlassian.net/browse/SRV-4904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ