### PR TITLE
GHA set-output deprecated

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Optionally check out code
       if: inputs.skip-checkout == 'false'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ inputs.elixir-version }}
@@ -44,7 +44,7 @@ runs:
     - name: Format Cache Version
       id: format-cache-version
       if: ${{ inputs.cache-key-version }}
-      run: echo "::set-output name=cache-key-version::_${{ inputs.cache-key-version }}"
+      run: echo "cache-key-version=_${{ inputs.cache-key-version }}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Compute Cache Key
       id: compute-cache-key
@@ -56,8 +56,8 @@ runs:
         version="${{ steps.format-cache-version.outputs.cache-key-version }}"
         suffix="${runner}_${erlang}_${elixir}_${mix_env}_${{ hashFiles('mix.lock') }}${version}"
         result="cache-deps_${suffix}"
-        echo "::set-output name=cache-key::$result"
-        echo "::set-output name=cache-key-suffix::$suffix"
+        echo "cache-key=$result" >> $GITHUB_OUTPUT
+        echo "cache-key-suffix=$suffix" >> $GITHUB_OUTPUT
       shell: bash
     - name: Configure Git Client with GitHub Auth Token
       shell: bash
@@ -65,7 +65,7 @@ runs:
       run: |
         git config --global url.https://${{ inputs.github-token }}@github.com/.insteadOf git@github.com:
     - id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ steps.compute-cache-key.outputs.cache-key }}
         path: |


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-4929)

- Resolve deprecated use of `set-output`.
- Update versions of `cache` and `checkout`.

Verified runs:
- cache miss: https://github.com/rentpath/seo_metadata_service/actions/runs/3988942301/jobs/6840757417
- cache hit: https://github.com/rentpath/seo_metadata_service/actions/runs/3988942301/jobs/6840788298